### PR TITLE
Add navigation bar and events section

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -22,6 +22,40 @@ export default function RootLayout({ children }) {
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <nav className="bg-white/80 backdrop-blur sticky top-0 z-10">
+          <div className="max-w-5xl mx-auto flex items-center justify-between px-4 py-3">
+            <a href="#" className="font-bold text-orange-600">
+              Rolling Bites
+            </a>
+            <ul className="flex space-x-4">
+              <li>
+                <a href="#about" className="hover:text-orange-600">
+                  About
+                </a>
+              </li>
+              <li>
+                <a href="#menu" className="hover:text-orange-600">
+                  Menu
+                </a>
+              </li>
+              <li>
+                <a href="#locations" className="hover:text-orange-600">
+                  Locations
+                </a>
+              </li>
+              <li>
+                <a href="#events" className="hover:text-orange-600">
+                  Events
+                </a>
+              </li>
+              <li>
+                <a href="#contact" className="hover:text-orange-600">
+                  Contact
+                </a>
+              </li>
+            </ul>
+          </div>
+        </nav>
         {children}
       </body>
     </html>

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -19,7 +19,7 @@ export default function Home() {
       </section>
 
       {/* About Section */}
-      <section className="max-w-3xl mx-auto text-center space-y-4">
+      <section id="about" className="max-w-3xl mx-auto text-center space-y-4">
         <h2 className="text-3xl font-bold text-orange-500">Our Story</h2>
         <p>
           We started with a dream to serve mouthwatering street eats across the city.
@@ -28,7 +28,7 @@ export default function Home() {
       </section>
 
       {/* Menu Section */}
-      <section className="max-w-5xl mx-auto">
+      <section id="menu" className="max-w-5xl mx-auto">
         <h2 className="text-3xl font-bold text-center text-orange-500 mb-8">Menu Favorites</h2>
         <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-6">
           {[
@@ -45,7 +45,7 @@ export default function Home() {
       </section>
 
       {/* Schedule Section */}
-      <section className="max-w-3xl mx-auto text-center space-y-6">
+      <section id="locations" className="max-w-3xl mx-auto text-center space-y-6">
         <h2 className="text-3xl font-bold text-orange-500">Where to Find Us</h2>
         <ul className="space-y-2">
           <li>Monday – Downtown Square</li>
@@ -54,8 +54,16 @@ export default function Home() {
         </ul>
       </section>
 
+      {/* Events Section */}
+      <section id="events" className="max-w-3xl mx-auto text-center space-y-6">
+        <h2 className="text-3xl font-bold text-orange-500">Events</h2>
+        <p>
+          Catch us at local festivals and community gatherings all season long!
+        </p>
+      </section>
+
       {/* Contact Section */}
-      <section className="max-w-md mx-auto space-y-6 text-center">
+      <section id="contact" className="max-w-md mx-auto space-y-6 text-center">
         <h2 className="text-3xl font-bold text-orange-500">Book Us</h2>
         <p>Looking to spice up your event? Reach out for catering or private bookings!</p>
         <a


### PR DESCRIPTION
## Summary
- add sticky navigation bar in layout
- link nav items to sections on the homepage
- add ids to sections and include a new Events section

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882e6568060832783530751f8929f9a