### PR TITLE
Add pages for nav links

### DIFF
--- a/src/app/about/page.js
+++ b/src/app/about/page.js
@@ -1,0 +1,14 @@
+export const metadata = {
+  title: "About - Rolling Bites",
+};
+
+export default function AboutPage() {
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-orange-100 to-yellow-50 text-zinc-800 px-4 sm:px-8 py-16 space-y-6">
+      <h1 className="text-4xl font-extrabold text-orange-600 text-center mb-4">Our Story</h1>
+      <p className="max-w-2xl mx-auto text-center">
+        We started with a dream to serve mouthwatering street eats across the city. From tacos to sliders, everything is made fresh with local ingredients.
+      </p>
+    </main>
+  );
+}

--- a/src/app/contact/page.js
+++ b/src/app/contact/page.js
@@ -1,0 +1,15 @@
+export const metadata = {
+  title: "Contact - Rolling Bites",
+};
+
+export default function ContactPage() {
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-orange-100 to-yellow-50 text-zinc-800 px-4 sm:px-8 py-16 space-y-6 text-center">
+      <h1 className="text-4xl font-extrabold text-orange-600 mb-4">Book Us</h1>
+      <p>Looking to spice up your event? Reach out for catering or private bookings!</p>
+      <a href="mailto:info@rollingbites.com" className="inline-block bg-orange-500 hover:bg-orange-600 text-white font-semibold py-2 px-6 rounded-xl">
+        Contact Us
+      </a>
+    </main>
+  );
+}

--- a/src/app/events/page.js
+++ b/src/app/events/page.js
@@ -1,0 +1,14 @@
+export const metadata = {
+  title: "Events - Rolling Bites",
+};
+
+export default function EventsPage() {
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-orange-100 to-yellow-50 text-zinc-800 px-4 sm:px-8 py-16 space-y-6">
+      <h1 className="text-4xl font-extrabold text-orange-600 text-center mb-4">Events</h1>
+      <p className="text-center max-w-xl mx-auto">
+        Catch us at local festivals and community gatherings all season long!
+      </p>
+    </main>
+  );
+}

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,4 +1,5 @@
 import { Geist, Geist_Mono } from "next/font/google";
+import Link from "next/link";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -24,34 +25,34 @@ export default function RootLayout({ children }) {
       >
         <nav className="bg-white/80 backdrop-blur sticky top-0 z-10">
           <div className="max-w-5xl mx-auto flex items-center justify-between px-4 py-3">
-            <a href="#" className="font-bold text-orange-600">
+            <Link href="/" className="font-bold text-orange-600">
               Rolling Bites
-            </a>
+            </Link>
             <ul className="flex space-x-4">
               <li>
-                <a href="#about" className="hover:text-orange-600">
+                <Link href="/about" className="hover:text-orange-600">
                   About
-                </a>
+                </Link>
               </li>
               <li>
-                <a href="#menu" className="hover:text-orange-600">
+                <Link href="/menu" className="hover:text-orange-600">
                   Menu
-                </a>
+                </Link>
               </li>
               <li>
-                <a href="#locations" className="hover:text-orange-600">
+                <Link href="/locations" className="hover:text-orange-600">
                   Locations
-                </a>
+                </Link>
               </li>
               <li>
-                <a href="#events" className="hover:text-orange-600">
+                <Link href="/events" className="hover:text-orange-600">
                   Events
-                </a>
+                </Link>
               </li>
               <li>
-                <a href="#contact" className="hover:text-orange-600">
+                <Link href="/contact" className="hover:text-orange-600">
                   Contact
-                </a>
+                </Link>
               </li>
             </ul>
           </div>

--- a/src/app/locations/page.js
+++ b/src/app/locations/page.js
@@ -1,0 +1,16 @@
+export const metadata = {
+  title: "Locations - Rolling Bites",
+};
+
+export default function LocationsPage() {
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-orange-100 to-yellow-50 text-zinc-800 px-4 sm:px-8 py-16 space-y-6">
+      <h1 className="text-4xl font-extrabold text-orange-600 text-center mb-4">Where to Find Us</h1>
+      <ul className="space-y-2 text-center">
+        <li>Monday – Downtown Square</li>
+        <li>Wednesday – West End Brewery</li>
+        <li>Friday – Farmers Market</li>
+      </ul>
+    </main>
+  );
+}

--- a/src/app/menu/page.js
+++ b/src/app/menu/page.js
@@ -1,0 +1,27 @@
+import Image from "next/image";
+
+export const metadata = {
+  title: "Menu - Rolling Bites",
+};
+
+const items = [
+  { name: "Spicy Chicken Taco", image: "https://sdmntprnortheu.oaiusercontent.com/files/00000000-32b4-61f4-935e-f5068849e5f2/raw?se=2025-07-23T15%3A10%3A33Z&sp=r&sv=2024-08-04&sr=b&scid=900c0afb-378b-5ab5-a7ca-30d15a1818c0&skoid=5c72dd08-68ae-4091-b4e1-40ccec0693ae&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2025-07-22T23%3A52%3A42Z&ske=2025-07-23T23%3A52%3A42Z&sks=b&skv=2024-08-04&sig=54A6sm9Qsdrmv7BdYggjlrFIKnu6Sh9t/GcXNxu6mV4%3D" },
+  { name: "Loaded Fries", image: "https://sdmntprcentralus.oaiusercontent.com/files/00000000-467c-61f5-90b8-7f4ca541a113/raw?se=2025-07-23T14%3A43%3A49Z&sp=r&sv=2024-08-04&sr=b&scid=11a8a0dd-91c2-5309-8029-d2a0f7ff7f9e&skoid=31bc9c1a-c7e0-460a-8671-bf4a3c419305&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2025-07-22T23%3A54%3A29Z&ske=2025-07-23T23%3A54%3A29Z&sks=b&skv=2024-08-04&sig=sqiy9hQ5yLpUobiivhGc95Xd09pQzSoNo5wxEcgsRbE%3D" },
+  { name: "Cheeseburger Slider", image: "https://sdmntpreastus.oaiusercontent.com/files/00000000-7780-61f9-b044-f0f4a0a9111a/raw?se=2025-07-23T14%3A54%3A30Z&sp=r&sv=2024-08-04&sr=b&scid=3eee10d1-d36d-5fde-a790-cfe013179960&skoid=31bc9c1a-c7e0-460a-8671-bf4a3c419305&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2025-07-22T23%3A54%3A16Z&ske=2025-07-23T23%3A54%3A16Z&sks=b&skv=2024-08-04&sig=yXnrXW1OH9hnCX1FZdvnBv8jyIzihMJorOcS6n/av4s%3D" },
+];
+
+export default function MenuPage() {
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-orange-100 to-yellow-50 text-zinc-800 px-4 sm:px-8 py-16 space-y-6">
+      <h1 className="text-4xl font-extrabold text-orange-600 text-center mb-8">Menu Favorites</h1>
+      <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-6 max-w-5xl mx-auto">
+        {items.map((item) => (
+          <div key={item.name} className="bg-white rounded-xl shadow p-4 text-center">
+            <Image src={item.image} alt={item.name} width={400} height={300} className="rounded-lg mb-2" />
+            <h3 className="font-semibold text-lg">{item.name}</h3>
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- build separate pages for About, Menu, Locations, Events and Contact
- link navbar to these new pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882e7eebb7c8327865a652507267394