### PR TITLE
Improve mobile responsiveness with hamburger nav

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,6 +1,6 @@
 import { Geist, Geist_Mono, Playfair_Display } from "next/font/google";
 import Image from "next/image";
-import Link from "next/link";
+import Navbar from "../components/Navbar";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -23,61 +23,18 @@ export const metadata = {
   description: "Food Truck Catering in Avon",
 };
 
+export const viewport = {
+  width: "device-width",
+  initialScale: 1,
+};
+
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <body
         className={`${geistSans.variable} ${geistMono.variable} ${playfair.variable} antialiased`}
       >
-        <nav className="bg-black text-white sticky top-0 z-10 shadow">
-          <div className="max-w-5xl mx-auto flex items-center justify-between px-4 py-3">
-            <Link
-              href="/"
-              className="flex items-center space-x-2 font-bold font-serif"
-            >
-              <Image
-                src="/images/truck.png"
-                alt="Food Truck logo"
-                width={32}
-                height={32}
-                className="rounded-full"
-              />
-              <span>Food Truck</span>
-            </Link>
-            <ul className="flex space-x-4">
-              <li>
-                <a href="#about" className="hover:text-orange-500">
-                  About
-                </a>
-              </li>
-              <li>
-                <a href="#menu" className="hover:text-orange-500">
-                  Menu
-                </a>
-              </li>
-              <li>
-                <a href="#locations" className="hover:text-orange-500">
-                  Locations
-                </a>
-              </li>
-              <li>
-                <a href="#events" className="hover:text-orange-500">
-                  Events
-                </a>
-              </li>
-              <li>
-                <a href="#mailing-list" className="hover:text-orange-500">
-                  Mailing List
-                </a>
-              </li>
-              <li>
-                <a href="#contact" className="hover:text-orange-500">
-                  Contact
-                </a>
-              </li>
-            </ul>
-          </div>
-        </nav>
+        <Navbar />
         {children}
         <footer className="bg-black text-white py-10 mt-16">
           <div className="max-w-5xl mx-auto flex flex-col items-center space-y-4">

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -13,7 +13,7 @@ export default function Home() {
           className="w-full h-auto object-cover rounded-b-[4rem]"
         />
         <div className="absolute inset-0 flex flex-col items-center justify-center text-center px-4 py-20 bg-black/40">
-          <h1 className="text-5xl md:text-6xl font-serif font-black">
+          <h1 className="text-3xl sm:text-5xl md:text-6xl font-serif font-black">
             <span className="text-white">Food Truck Catering in Avon </span>
             <span className="text-orange-600">Savor Delicious Flavors on Wheels</span>
           </h1>

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -1,0 +1,66 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { useState } from 'react';
+
+export default function Navbar() {
+  const [open, setOpen] = useState(false);
+  return (
+    <nav className="bg-black text-white sticky top-0 z-10 shadow">
+      <div className="max-w-5xl mx-auto flex items-center justify-between px-4 py-3">
+        <Link href="/" className="flex items-center space-x-2 font-bold font-serif">
+          <Image
+            src="/images/truck.png"
+            alt="Food Truck logo"
+            width={32}
+            height={32}
+            className="rounded-full"
+          />
+          <span>Food Truck</span>
+        </Link>
+        <button
+          className="md:hidden"
+          onClick={() => setOpen(!open)}
+          aria-label="Toggle navigation"
+        >
+          <span className="text-2xl">☰</span>
+        </button>
+        <ul
+          className={`${open ? 'flex' : 'hidden'} flex-col space-y-2 md:flex md:flex-row md:space-y-0 md:space-x-4`}
+        >
+          <li>
+            <a href="#about" className="hover:text-orange-500">
+              About
+            </a>
+          </li>
+          <li>
+            <a href="#menu" className="hover:text-orange-500">
+              Menu
+            </a>
+          </li>
+          <li>
+            <a href="#locations" className="hover:text-orange-500">
+              Locations
+            </a>
+          </li>
+          <li>
+            <a href="#events" className="hover:text-orange-500">
+              Events
+            </a>
+          </li>
+          <li>
+            <a href="#mailing-list" className="hover:text-orange-500">
+              Mailing List
+            </a>
+          </li>
+          <li>
+            <a href="#contact" className="hover:text-orange-500">
+              Contact
+            </a>
+          </li>
+        </ul>
+      </div>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- Add responsive navigation bar with hamburger menu on small screens
- Scale hero heading for better mobile readability
- Specify viewport meta to ensure proper sizing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68967cf91ac883279825e340c9126fd0